### PR TITLE
remove propTypes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,7 +56,7 @@
 		"react/no-string-refs": 2,
 		"react/no-unknown-property": 2,
 		"react/prefer-es6-class": 2,
-		"react/prop-types": 2,
+		"react/prop-types": 0,
 		"react/react-in-jsx-scope": 2,
 		"react/require-extension": [2, { "extensions": [".js", ".jsx"] }],
 		"react/self-closing-comp": 2,

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,5 @@
 import ItemList from './ItemList';
-import React, { PropTypes } from 'react';
+import React from 'react';
 import Relay from 'react-relay';
 import relay from 'relay-decorator';
 
@@ -16,15 +16,6 @@ import relay from 'relay-decorator';
 	},
 })
 export default class App extends React.Component {
-	static propTypes = {
-		relay: PropTypes.shape({
-			variables: PropTypes.shape({
-				first: ItemList.propTypes.first,
-			}).isRequired,
-		}).isRequired,
-		viewer: ItemList.propTypes.viewer,
-	};
-
 	render() {
 		return (
 			<ItemList

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,5 +1,5 @@
 import AddItemMutation from '../mutations/AddItemMutation';
-import React, { PropTypes } from 'react';
+import React from 'react';
 import Relay from 'react-relay';
 import relay from 'relay-decorator';
 
@@ -19,13 +19,6 @@ import relay from 'relay-decorator';
 	},
 })
 export default class Item extends React.Component {
-	static propTypes = {
-		item: PropTypes.shape({
-			id: PropTypes.string.isRequired,
-			date: PropTypes.number.isRequired,
-		}).isRequired,
-	};
-
 	render() {
 		const { item: { id, date } } = this.props;
 		return (

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -1,5 +1,5 @@
 import Item from './Item';
-import React, { PropTypes } from 'react';
+import React from 'react';
 import Relay from 'react-relay';
 import relay from 'relay-decorator';
 
@@ -24,17 +24,6 @@ import relay from 'relay-decorator';
 	},
 })
 export default class ItemList extends React.Component {
-	static propTypes = {
-		first: PropTypes.number.isRequired,
-		viewer: PropTypes.shape({
-			items: PropTypes.shape({
-				edges: PropTypes.arrayOf(
-					Item.propTypes.item
-				).isRequired,
-			}).isRequired,
-		}).isRequired,
-	};
-
 	render() {
 		return (
 			<div>


### PR DESCRIPTION
because `Item.propTypes.item` doesn't work through Relay's wrapper